### PR TITLE
Use get_phantom_base_url instead of 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **custom_ssl_certificate** | optional | boolean | Use Custom SSL Certificate |
 **ssl** | optional | boolean | Use SSL |
 **custom_ssl_certificate_path** | optional | string | Custom SSL Certificate Path |
-**http_port** | optional | string | Splunk SOAR HTTPS port (default: 8443) |
 
 ### Supported Actions
 

--- a/domaintools_iris.json
+++ b/domaintools_iris.json
@@ -91,12 +91,6 @@
             "description": "Custom SSL Certificate Path",
             "data_type": "string",
             "order": 10
-        },
-        "http_port": {
-            "description": "Splunk SOAR HTTPS port (default: 8443)",
-            "data_type": "string",
-            "default": "8443",
-            "order": 11
         }
     },
     "actions": [

--- a/domaintools_iris_connector.py
+++ b/domaintools_iris_connector.py
@@ -12,7 +12,6 @@ import sys
 from datetime import datetime, timedelta
 
 import phantom.app as phantom
-import phantom.rules as phrules
 import requests
 import tldextract
 

--- a/domaintools_iris_connector.py
+++ b/domaintools_iris_connector.py
@@ -55,7 +55,7 @@ class DomainToolsConnector(BaseConnector):
         self.app_version_number = app_json_configuration.get("app_version", "")
         self.app_name = app_json_configuration.get("name", "")
         self.app_partner = "splunk_soar"
-        self._rest_url = phrules.build_phantom_rest_url()
+        self._rest_url = f"{self.get_phantom_base_url()}/rest"
 
         # Fetching the Python major version
         try:

--- a/domaintools_iris_connector.py
+++ b/domaintools_iris_connector.py
@@ -12,6 +12,7 @@ import sys
 from datetime import datetime, timedelta
 
 import phantom.app as phantom
+import phantom.rules as phrules
 import requests
 import tldextract
 
@@ -54,7 +55,7 @@ class DomainToolsConnector(BaseConnector):
         self.app_version_number = app_json_configuration.get("app_version", "")
         self.app_name = app_json_configuration.get("name", "")
         self.app_partner = "splunk_soar"
-        self._rest_url = self._build_rest_url()
+        self._rest_url = phrules.build_phantom_rest_url()
 
         # Fetching the Python major version
         try:
@@ -637,14 +638,6 @@ class DomainToolsConnector(BaseConnector):
             return action_result.get_data()
 
         return action_result.get_status()
-
-    def _build_rest_url(self):
-        self.debug_print(self.get_config())
-        http_port = self.get_config().get("http_port")
-        if http_port:
-            return f"https://127.0.0.1:{http_port}/rest/"
-
-        return "https://127.0.0.1:8443/rest/"
 
     def _get_scheduled_playbooks(self):
         response = phantom.requests.get(

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,2 @@
 **Unreleased**
-* Use build_phantom_rest_url instead of 127.0.0.1
+* Use get_phantom_base_url instead of 127.0.0.1

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Use build_phantom_rest_url instead of 127.0.0.1


### PR DESCRIPTION
### Bug Fixes
- Fixes SOARHELP-4539 by removing the hard-coded 127.0.0.1

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
